### PR TITLE
Base Detail Fix

### DIFF
--- a/detail/base_detail.handlebars
+++ b/detail/base_detail.handlebars
@@ -1,15 +1,14 @@
 <div class="cw">
-  <div class="zci__main  zci__main--detail  c-base">
-      <div class="zci__body">{{#if content}}{{{content}}}{{else}}{{{include meta.options.content}}}{{/if}}
-        <div class="c-base__links">
-          {{#if meta.options.moreAt}}
-              {{{moreAt meta 'none' className="c-base__link"}}}
-          {{/if}}
-          {{#if meta.options.moreText}}
-              <span class="c-base__link--more  sep--before">{{{formatSubtitle meta.options.moreText}}}</span>
-          {{/if}}
+    <div class="zci__main  zci__main--detail  c-base">
+        <div class="zci__body">{{#if content}}{{{content}}}{{else}}{{{include meta.options.content}}}{{/if}}
+            {{#if meta.options.moreAt}}
+                <div class="c-base__links">
+                    {{{moreAt meta 'none' className="c-base__link"}}}
+                    {{#if meta.options.moreText}}
+                        <span class="c-base__link--more  sep--before">{{{formatSubtitle meta.options.moreText}}}</span>
+                    {{/if}}
+                </div>
+            {{/if}}
         </div>
     </div>
-  </div>
 </div>
-


### PR DESCRIPTION
Fixes the spacing to be more readable, and corrects the problem where `.c-base__links` is being erroneously included, which results in some undesirable layouts.

to @bsstoner 
cc @chrismorast @abeyang 