### PR TITLE
Detail Content classNames

### DIFF
--- a/item_detail/images_detail.handlebars
+++ b/item_detail/images_detail.handlebars
@@ -6,13 +6,13 @@
         </span>
     </div>
     <div class="detail__body  detail__body--images">
-        <div class="detail__body__content">
-            <h5 class="detail__title"><a href="{{url}}">{{title}}</a></h5>
-            <div class="detail__desc">
+        <div class="c-detail  detail__body__content">
+            <h5 class="c-detail__title"><a href="{{url}}">{{title}}</a></h5>
+            <div class="c-detail__desc">
                 <p><a href="{{url}}">{{domain url}}</a></p>
-                <div class="detail__filemeta">
+                <div class="c-detail__filemeta">
                     {{width}} &times; {{height}}
-                    <span class="sep  detail__sep"></span>
+                    <span class="sep  c-detail__sep"></span>
                     <a href="{{image}}">DDG.Text.VIEW_FILE</a>
                 </div>
             </div>

--- a/item_detail/media_item_detail.handlebars
+++ b/item_detail/media_item_detail.handlebars
@@ -5,19 +5,19 @@
         </div>
     {{/if}}
     <div class="detail__body {{meta.elClass.detailBody}}">
-        <div class="detail__body__content">
-            <h5 class="detail__title {{meta.elClass.detailTitle}}">
+        <div class="c-detail detail__body__content">
+            <h5 class="c-detail__title {{meta.elClass.detailTitle}}">
                 {{title}}
-                {{#if altSubtitle}}<span class="detail__title__sub {{meta.elClass.detailAltSubtitle}}">{{{formatSubtitle altSubtitle}}}</span>{{/if}}
+                {{#if altSubtitle}}<span class="c-detail__title__sub {{meta.elClass.detailAltSubtitle}}">{{{formatSubtitle altSubtitle}}}</span>{{/if}}
             </h5>
-            {{#if subtitle}}<span class="detail__subtitle {{meta.elClass.detailSubtitle}}">{{{formatSubtitle subtitle}}}</span>{{/if}}
+            {{#if subtitle}}<span class="c-detail__subtitle {{meta.elClass.detailSubtitle}}">{{{formatSubtitle subtitle}}}</span>{{/if}}
             {{#if description}}
-            <div class="detail__desc {{meta.elClass.detailSnippet}}">
+            <div class="c-detail__desc {{meta.elClass.detailSnippet}}">
                 {{ellipsis description meta.snippetChars fallback=155}}
             </div>
             {{/if}}
             {{#if meta.options.callout}}
-            <div class="detail__callout {{meta.elClass.detailFoot}}">
+            <div class="c-detail__callout {{meta.elClass.detailFoot}}">
                 {{{include meta.options.callout}}}
             </div>
             {{/if}}

--- a/item_detail/products_item_detail.handlebars
+++ b/item_detail/products_item_detail.handlebars
@@ -1,37 +1,37 @@
 <div class="detail__inner">
     {{#if img_m}}
-      <div class="detail__media  detail__media--pr">
-        <img class="detail__media__img" src="{{imageProxy img_m}}" />
-      </div>
+        <div class="detail__media  detail__media--pr">
+            <img class="detail__media__img" src="{{imageProxy img_m}}" />
+        </div>
     {{/if}}
     <div class="detail__body  detail__body--pr">
-      <div class="detail__body__content">
-        {{{formatTitle heading href=url el="h5" className="detail__title" classNameSec="detail__tile--pr" ellipsis=120 }}}
-        <p class="detail__subtitle">
-          {{#and meta.options.price price}}
-            <span class="detail__price  price  tx-clr--dk2">{{price}}</span>
-          {{/and}}
-          {{#and meta.options.price meta.options.brand price brand}}
-            <span class="sep  detail__sep"></span>
-          {{/and}}                    
-          {{#and meta.options.brand brand}}
-            <span class="detail__brand">DDG.Text.MADE_BY_BRAND</span>
-          {{/and}}
-          {{#if meta.options.subtitle_content}}
-            {{{include meta.options.subtitle_content}}}
-          {{/if}}
-        </p>
-        {{#if meta.options.rating}}
-          <p class="detail__rating">
-            {{{starsAndReviews rating reviewCount url_review}}}
-          </p>
-        {{/if}}
-        <p class="detail__desc  hide--screen-xs">
-          {{{abstract}}}
-        </p>
-        {{#if meta.options.buy}}
-          {{{include meta.options.buy}}}
-        {{/if}}
-      </div>
+        <div class="c-detail  detail__body__content">
+            {{{formatTitle heading href=url el="h5" className="c-detail__title" ellipsis=120 }}}
+            <p class="c-detail__subtitle">
+                {{#and meta.options.price price}}
+                    <span class="c-detail__price  price  tx-clr--dk2">{{price}}</span>
+                {{/and}}
+                {{#and meta.options.price meta.options.brand price brand}}
+                    <span class="sep  c-detail__sep"></span>
+                {{/and}}
+                {{#and meta.options.brand brand}}
+                    <span class="c-detail__brand">DDG.Text.MADE_BY_BRAND</span>
+                {{/and}}
+                {{#if meta.options.subtitle_content}}
+                    {{{include meta.options.subtitle_content}}}
+                {{/if}}
+            </p>
+            {{#if meta.options.rating}}
+                <p class="c-detail__rating">
+                    {{{starsAndReviews rating reviewCount url_review}}}
+                </p>
+            {{/if}}
+            <p class="c-detail__desc  hide--screen-xs">
+                {{{abstract}}}
+            </p>
+            {{#if meta.options.buy}}
+                {{{include meta.options.buy}}}
+            {{/if}}
+        </div>
     </div>
 </div>

--- a/item_detail/qa_detail.handlebars
+++ b/item_detail/qa_detail.handlebars
@@ -1,9 +1,9 @@
 <div class="detail__inner">
     <div class="detail__body  detail__body--qa">
-        <div class="detail__body__content  detail__body__content--qa">
-            <h4 class="detail__title  detail__title--qa"><a href="{{url}}">{{{heading}}}</a></h4>
+        <div class="c-detail detail__body__content  detail__body__content--qa">
+            <h4 class="c-detail__title  detail__title--qa"><a href="{{url}}">{{{heading}}}</a></h4>
             <div class="chomp--scroll">{{{abstract}}}</div>
-            <p class="detail__more">{{{moreAt url source}}}</p>
+            <p class="c-detail__more">{{{moreAt url source}}}</p>
         </div>
     </div>
 </div>

--- a/item_detail/videos_detail.handlebars
+++ b/item_detail/videos_detail.handlebars
@@ -3,34 +3,34 @@
         <div class="detail__media__vid-wrap  js-video-media" style="background-image:url('{{imageProxy images.medium}}');"></div>
     </div>
     <div class="detail__body">
-        <div class="detail__body__content">
-            <h5 class="detail__title"><a href='{{url}}' title="{{title}}">{{title}}</a></h5>
-            <div class="detail__desc">
-                <p class="detail__user"><i class="detail__icon  detail__user__icon">u</i> <a href='{{userURL}}'>{{{username}}}</a></p>
-                <p class="detail__count"><i class="detail__icon  detail__count__icon">i</i> {{{viewCount}}}</p>
-                <p class="detail__date"><i class="detail__icon detail__date__icon">&uArr;</i> {{{publishedDate}}}</p>
+        <div class="c-detail  detail__body__content">
+            <h5 class="c-detail__title"><a href='{{url}}' title="{{title}}">{{title}}</a></h5>
+            <div class="c-detail__desc">
+                <p class="c-detail__user"><i class="c-detail__icon  c-detail__user__icon">u</i> <a href='{{userURL}}'>{{{username}}}</a></p>
+                <p class="c-detail__count"><i class="c-detail__icon  c-detail__count__icon">i</i> {{{viewCount}}}</p>
+                <p class="c-detail__date"><i class="c-detail__icon  c-detail__date__icon">&uArr;</i> {{{publishedDate}}}</p>
             </div>    
                 {{#if musicVideo}}
-                    <h6 class="detail__links--title">DDG.Text.GET_THIS_SONG_ON</h6>
-                    <p class="detail__links">
-                      <a href='/?q={{musicVideo.spotifyURL}}' class='btn detail__links__btn'>
+                    <h6 class="c-detail__links--title">DDG.Text.GET_THIS_SONG_ON</h6>
+                    <p class="c-detail__links">
+                      <a href='/?q={{musicVideo.spotifyURL}}' class='btn c-detail__links__btn'>
                         {{{favicon "spotify" className="btn__icon" w="auto" h="auto"}}}
                         Spotify
                       </a>
                       
-                      <a href='/?q={{musicVideo.amazonURL}}' class='btn detail__links__btn'>
+                      <a href='/?q={{musicVideo.amazonURL}}' class='btn c-detail__links__btn'>
                         {{{favicon "amazon" className="btn__icon" w="auto" h="auto"}}}
                         Amazon  
                       </a>
                           
-                      <a style="display: none;" href='' id="video-detail-itunes" class='btn detail__links__btn' data-title='{{musicVideo.title}}' data-artist='{{musicVideo.artist}}' data-song='{{musicVideo.song}}'>
+                      <a style="display: none;" href='' id="video-detail-itunes" class='btn c-detail__links__btn' data-title='{{musicVideo.title}}' data-artist='{{musicVideo.artist}}' data-song='{{musicVideo.song}}'>
                         {{{favicon "apple" className="btn__icon" w="auto" h="auto"}}}
                         iTunes  
                       </a>
                     </p>
                 {{/if}}
                 
-                <p class="detail__more">{{{moreAt searchURL provider className=" " iconClassName="detail__icon" iconUrl=faviconURL}}}</p>
+                <p class="c-detail__more">{{{moreAt searchURL provider className=" " iconClassName="c-detail__icon" iconUrl=faviconURL}}}</p>
             
         </div>
     </div>


### PR DESCRIPTION
We're breaking apart all of the `detail` classes and separating the content from the structure.  This is the first step, making sure the core styling doesn't break.  From here we'll create new detail wrapping structures and adjust the include methods.

Requires an internal PR.

to @bsstoner 