### PR TITLE
Add option to hide the review text in a product template

### DIFF
--- a/detail/products_detail.handlebars
+++ b/detail/products_detail.handlebars
@@ -15,7 +15,7 @@
                     {{else}}
                       {{subtitle}}
                       {{#if meta.options.rating}}
-                        <span class="c-product__rating {{#if subtitle}}sep--before{{/if}}">{{{starsAndReviews rating reviewCount url}}}</span>
+                        <span class="c-product__rating {{#if subtitle}}sep--before{{/if}}">{{{starsAndReviews rating reviewCount url meta.options.hideReviewText}}}</span>
                       {{/if}}
                       {{#and meta.options.price meta.options.rating price}}
                         <span class="sep  c-product__sep"></span>

--- a/item/products_item.handlebars
+++ b/item/products_item.handlebars
@@ -21,7 +21,7 @@
 	</div>
         {{#if meta.options.rating}}
 		<div class="tile__tx  tile__rating  one-line">
-			{{{starsAndReviews rating reviewCount url_review true}}}
+			{{{starsAndReviews rating reviewCount url_review meta.options.hideReviewText}}}
 		</div>
         {{/if}}
 	</div>

--- a/item/products_item.handlebars
+++ b/item/products_item.handlebars
@@ -21,7 +21,7 @@
 	</div>
         {{#if meta.options.rating}}
 		<div class="tile__tx  tile__rating  one-line">
-			{{{starsAndReviews rating reviewCount url_review meta.options.hideReviewText}}}
+			{{{starsAndReviews rating reviewCount url_review true}}}
 		</div>
         {{/if}}
 	</div>

--- a/item_detail/products_item_detail.handlebars
+++ b/item_detail/products_item_detail.handlebars
@@ -23,7 +23,7 @@
             </p>
             {{#if meta.options.rating}}
                 <p class="c-detail__rating">
-                    {{{starsAndReviews rating reviewCount url_review}}}
+                    {{{starsAndReviews rating reviewCount url_review meta.options.hideReviewText}}}
                 </p>
             {{/if}}
             <p class="c-detail__desc  hide--screen-xs">

--- a/templates.js
+++ b/templates.js
@@ -38,7 +38,8 @@
                 options: {
                     rating: true,
                     price: true,
-                    brand: true
+                    brand: true,
+                    hideReviewText: false
                 }
             },
             products_simple: {


### PR DESCRIPTION
We have a helper function called {{starsAndReviews}} which actually accepts 4 arguments (the 4th one being the one that controls whether the review text is show or not) but it's not all being used. By passing meta.options.hideReviewText as the 4th argument, we'd be able to control the review text from a Spice / Goodie / whatever uses this template.

There's no need to change any of the Spices since nothing has changed logically in the code (default is still `hideReviewText: false`--same as before)

CC @bsstoner @sdougbrown 