### PR TITLE
Mobile Attribution Fix

### DIFF
--- a/shared/attribution.handlebars
+++ b/shared/attribution.handlebars
@@ -1,4 +1,4 @@
-<span class="popout-trig  js-popout {{popout.className}}  hide--screen-s">
+<span class="popout-trig  js-popout {{popout.className}}  hide--screen-s  hide--mob">
 	<a class="attribution--link  js-popout-link"><span class="attribution--link__icon  ddgsi">I</span></a>
 <div class="popout-wrap  popout-wrap--{{popout.direction}}">
 	<div class="popout  popout--{{popout.direction}}  popout--lg  js-popout-main">


### PR DESCRIPTION
iPhone6+ landscape is larger than `screen--s` and we want to make sure this element is always hidden on mobile.

to @bsstoner 