### PR TITLE
Add ability to use item specific elClass on tiles

### DIFF
--- a/item/audio_item.handlebars
+++ b/item/audio_item.handlebars
@@ -1,4 +1,4 @@
-<div class="tile  tile--c--n  tile--audio  tile--no-highlight">
+<div class="tile  tile--c--n  tile--audio  tile--no-highlight {{#if elClass}}{{elClass}}{{else}}{{meta.elClass.tile}}{{/if}}">
     <div class="tile__media">
         {{#if image}}
         <img class="tile__media__img" src="{{imageProxy image}}" />

--- a/item/base_expanding_item.handlebars
+++ b/item/base_expanding_item.handlebars
@@ -1,4 +1,4 @@
-<div class="tile  tile--e  tile--{{meta.id}}  tile--no-highlight  tile--c--whole  {{meta.elClass.tile}}">
+<div class="tile  tile--e  tile--{{meta.id}}  tile--no-highlight  tile--c--whole  {{#if elClass}}{{elClass}}{{else}}{{meta.elClass.tile}}{{/if}}">
 	{{{include meta.options.content}}}
 	{{#if canExpand}}
 		<span class="tile__expand-icon  ddgsi  {{meta.elClass.tileExpand}}"></span>

--- a/item/base_flipping_item.handlebars
+++ b/item/base_flipping_item.handlebars
@@ -1,4 +1,4 @@
-<div class="tile  tile--f  tile--{{meta.id}}  {{meta.elClass.tile}}">
+<div class="tile  tile--f  tile--{{meta.id}}  {{#if elClass}}{{elClass}}{{else}}{{meta.elClass.tile}}{{/if}}">
 	<div class="tile--f__main {{meta.elClass.tileFront}}">
 		{{{include meta.options.front_content}}}
 	</div>

--- a/item/base_item.handlebars
+++ b/item/base_item.handlebars
@@ -1,3 +1,3 @@
-<div class="tile  tile--b {{#unless meta.elClass.tile}} tile--c {{else}} {{meta.elClass.tile}} {{/unless}} tile--{{meta.id}}" {{#if url}}data-link="{{url}}"{{/if}}>  
+<div class="tile  tile--b {{#if elClass}}{{elClass}}{{else}}{{#if meta.elClass.tile}}{{meta.elClass.tile}}{{else}}tile--c{{/if}}{{/if}} tile--{{meta.id}}" {{#if url}}data-link="{{url}}"{{/if}}>  
   <div class="tile__body">{{#if meta.options.tile_content}}{{{include meta.options.tile_content}}}{{else}}{{{include meta.options.content}}}{{/if}}</div>
 </div>

--- a/item/basic_flipping_item.handlebars
+++ b/item/basic_flipping_item.handlebars
@@ -1,4 +1,4 @@
-<div class="tile  tile--f  tile--{{meta.id}}  {{meta.elClass.tile}}">
+<div class="tile  tile--f  tile--{{meta.id}}  {{#if elClass}}{{elClass}}{{else}}{{meta.elClass.tile}}{{/if}}">
 	<div class="tile--f__main {{meta.elClass.tileFront}}">
 		{{#with data_front}}
 			{{{include 'tile_body' meta=../meta num=../num}}}

--- a/item/basic_image_item.handlebars
+++ b/item/basic_image_item.handlebars
@@ -1,4 +1,4 @@
-<div class="tile  tile--b--i {{#unless meta.elClass.tile}} tile--c {{else}} {{meta.elClass.tile}} {{/unless}} has-detail  tile--{{meta.id}}  opt--t-xxs" {{#if url}} data-link="{{url}}"{{/if}}>
+<div class="tile  tile--b--i {{#if elClass}}{{elClass}}{{else}}{{#if meta.elClass.tile}}{{meta.elClass.tile}}{{else}}tile--c{{/if}}{{/if}} has-detail  tile--{{meta.id}}  opt--t-xxs" {{#if url}} data-link="{{url}}"{{/if}}>
 	<div class="tile__media {{meta.elClass.tileMedia}}">
 		<img src="{{imageProxy image}}" alt="{{title}}" class="tile__media__img {{meta.elClass.tileMediaImg}}" />
 	</div>

--- a/item/media_item.handlebars
+++ b/item/media_item.handlebars
@@ -1,4 +1,4 @@
-<div class="tile {{#unless meta.elClass.tile}} tile--c {{else}} {{meta.elClass.tile}} {{/unless}} tile--{{meta.id}}" {{#if url}}data-link="{{url}}"{{/if}}>
+<div class="tile {{#if elClass}}{{elClass}}{{else}}{{#if meta.elClass.tile}}{{meta.elClass.tile}}{{else}}tile--c{{/if}}{{/if}} tile--{{meta.id}}" {{#if url}}data-link="{{url}}"{{/if}}>
     <div class="tile__media {{meta.elClass.tileMedia}}">
         <img src="{{imageProxy image}}" alt="{{title}}" class="tile__media__img" />
     </div>

--- a/item/places_item.handlebars
+++ b/item/places_item.handlebars
@@ -1,4 +1,4 @@
-<div class="tile  tile--f  tile--loc">
+<div class="tile  tile--f  tile--loc {{#if elClass}}{{elClass}}{{else}}{{meta.elClass.tile}}{{/if}}">
 	<div class="tile--f__main  tile--loc__main">
         <div class="tile__media">
             {{#if image}}

--- a/item/products_item.handlebars
+++ b/item/products_item.handlebars
@@ -1,4 +1,4 @@
-<div class="tile  tile--pr {{#unless meta.elClass.tile}} tile--c {{else}} {{meta.elClass.tile}} {{/unless}} has-detail  tile--{{parentId}} {{#if meta.options.rating}} has-rating{{/if}} opt--t-xxs" data-link="{{url}}">
+<div class="tile  tile--pr {{#if elClass}}{{elClass}}{{else}}{{#if meta.elClass.tile}}{{meta.elClass.tile}}{{else}}tile--c{{/if}}{{/if}} has-detail  tile--{{parentId}} {{#if meta.options.rating}} has-rating{{/if}} opt--t-xxs" data-link="{{url}}">
 	<div class="tile__media  tile__media--pr">
 		<img src="" data-src="{{{imageProxy img}}}" alt="{{title}}" class="tile__media__img  js-lazyload" />
 	</div>

--- a/item/text_item.handlebars
+++ b/item/text_item.handlebars
@@ -1,4 +1,4 @@
-<div class="tile {{#unless meta.elClass.tile}} tile--c {{else}} {{meta.elClass.tile}} {{/unless}} tile--{{meta.id}}" {{#if url}}data-link="{{url}}"{{/if}}>
+<div class="tile {{#if elClass}}{{elClass}}{{else}}{{#if meta.elClass.tile}}{{meta.elClass.tile}}{{else}}tile--c{{/if}}{{/if}} tile--{{meta.id}}" {{#if url}}data-link="{{url}}"{{/if}}>
     <div class="tile__body {{#if meta.options.footer}}has-foot{{/if}} {{meta.elClass.tileBody}}">
         {{{include 'tile_titles'}}}
         <div class="tile__content {{meta.elClass.tileSnippet}}">


### PR DESCRIPTION
@moollaza wanted this functionality. I can't remember which IA was going to use it, but they wanted to specify a top level class for certain items that would let control the entire tile's state. Maybe Flights?

@sdougbrown would like your thoughts on this.

I'd also love to rename `elClass` to something more intelligible... but that's probably outside the scope of this.