### PR TITLE
"Hybrid" Modal Refactor

### DIFF
--- a/core/filter_dropdown.handlebars
+++ b/core/filter_dropdown.handlebars
@@ -1,7 +1,7 @@
 <div class="metabar__dropdown {{#if disabled}}metabar__dropdown--disabled{{/if}} metabar__dropdown--{{key}}">
     <a href="#" class="metabar__dropdown__selected js-dropdown-selected">{{values.0.name}}</a>
     <div class="metabar__dropdown__modal modal modal--popout modal--popout--bottom js-dropdown-popout">
-        <div class="metabar__dropdown__box modal__box">
+        <div class="modal__box">
             <div class="modal__body">
                 <ol class="modal__list">
                 {{#each values}}

--- a/core/filter_dropdown.handlebars
+++ b/core/filter_dropdown.handlebars
@@ -1,12 +1,12 @@
 <div class="metabar__dropdown {{#if disabled}}metabar__dropdown--disabled{{/if}} metabar__dropdown--{{key}}">
     <a href="#" class="metabar__dropdown__selected js-dropdown-selected">{{values.0.name}}</a>
-    <div class="metabar__dropdown__popout-wrap popout-wrap popout-wrap--bottom">
-        <div class="metabar__dropdown__popout popout js-dropdown-popout popout--bottom">
-            <div class="popout__body">
-                <ol class="popout__list">
+    <div class="metabar__dropdown__modal modal modal--popout modal--popout--bottom js-dropdown-popout">
+        <div class="metabar__dropdown__box modal__box">
+            <div class="modal__body">
+                <ol class="modal__list">
                 {{#each values}}
                     <li>
-                        <a href="#" data-value="{{id}}" class="popout__list__link metabar__dropdown__item {{#if disabled}}is-disabled{{/if}} {{#if selected}}is-selected{{/if}} js-dropdown-items">{{name}}</a>
+                        <a href="#" data-value="{{id}}" class="modal__list__link metabar__dropdown__item {{#if disabled}}is-disabled{{/if}} {{#if selected}}is-selected{{/if}} js-dropdown-items">{{name}}</a>
                     </li>
                 {{/each}}
                 </ol>

--- a/shared/attribution.handlebars
+++ b/shared/attribution.handlebars
@@ -1,3 +1,3 @@
-<span class="popout-trig  {{className}}  hide--screen-s  hide--mob">
+<span class="modal-trig  {{className}}  hide--screen-s  hide--mob">
     <a class="attribution--link  js-attribution-link"><span class="attribution--link__icon  ddgsi">I</span></a>
 </span>

--- a/shared/attribution_modal.handlebars
+++ b/shared/attribution_modal.handlebars
@@ -1,18 +1,21 @@
-<div class="popout-wrap  popout-wrap--{{direction}}">
-    <div class="popout  popout--{{direction}}  popout--lg">
-        <div class="popout__body">
-            <div class="attribution">
-                <p class="tx-clr--slate">DDG.Text.ATTRIBUTION_STRING</p>
-                <hr class="attribution__hr"/>
-                {{#if devs}}
-                    {{#each devs}}
-                        <div class="tx-clr--slate-light">DDG.Text.ATTRIBUTION_DEV: <b class="tx-clr--slate">{{this.name}}</b></div>
-                    {{/each}}
+<div class="modal  modal--popout  modal--popout--{{direction}}  modal--popout--lg">
+    <div class="modal__overlay js-modal-close"></div>
+    <div class="modal__wrap">
+        <div class="modal__box">
+            <div class="modal__body">
+                <div class="attribution">
+                    <p class="tx-clr--slate">DDG.Text.ATTRIBUTION_STRING</p>
                     <hr class="attribution__hr"/>
-                {{/if}}
-                <div class="gw">
-                    <div class="g whole">
-                        <a href="https://duck.co/ia/view/{{meta.signal_from}}" class="btn btn--full attribution__btn">DDG.Text.MORE_INFO</a>
+                    {{#if devs}}
+                        {{#each devs}}
+                            <div class="tx-clr--slate-light">DDG.Text.ATTRIBUTION_DEV: <b class="tx-clr--slate">{{this.name}}</b></div>
+                        {{/each}}
+                        <hr class="attribution__hr"/>
+                    {{/if}}
+                    <div class="gw">
+                        <div class="g whole">
+                            <a href="https://duck.co/ia/view/{{meta.signal_from}}" class="btn btn--full attribution__btn">DDG.Text.MORE_INFO</a>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Shared classes and markup structure allow us to change modals from a 'popout' to a 'popover' a lot more easily.

See also: 
https://github.com/duckduckgo/duckduckgo-styles/pull/12
https://github.com/duckduckgo/duckduckgo-publisher/tree/doug/hybrid-modals