### PR TITLE
Video Detail Template: Don't show user line if there's no username

### DIFF
--- a/item_detail/videos_detail.handlebars
+++ b/item_detail/videos_detail.handlebars
@@ -6,7 +6,9 @@
         <div class="c-detail  detail__body__content">
             <h5 class="c-detail__title"><a href='{{url}}' title="{{title}}">{{title}}</a></h5>
             <div class="c-detail__desc">
-                <p class="c-detail__user"><i class="c-detail__icon  c-detail__user__icon">u</i> <a href='{{userURL}}'>{{{username}}}</a></p>
+                {{#if username}}
+                    <p class="c-detail__user"><i class="c-detail__icon  c-detail__user__icon">u</i> <a href='{{userURL}}'>{{{username}}}</a></p>
+                {{/if}}
                 <p class="c-detail__count"><i class="c-detail__icon  c-detail__count__icon">i</i> {{{viewCount}}}</p>
                 <p class="c-detail__date"><i class="c-detail__icon  c-detail__date__icon">&uArr;</i> {{{publishedDate}}}</p>
             </div>    


### PR DESCRIPTION
![screen shot 2015-11-18 at 3 17 15 pm](https://cloud.githubusercontent.com/assets/126358/11282756/fbae5692-8ece-11e5-9ecb-c1a0c463381a.png)

YouTube isn't returning the user name for some videos, so rather than show the user icon with the empty space, this just hides the entire line when there's no username.

@andrey-p 

