### PR TITLE
detail/text_detail.handlebars: Make sure to check if we have anything to display before adding the element.

### DIFF
--- a/detail/text_detail.handlebars
+++ b/detail/text_detail.handlebars
@@ -29,7 +29,7 @@
       {{/if}}
 
       <!-- Make sure to check if we have anything to display before adding the element. -->
-      {{#if meta.options.moreText}}
+      {{#or meta.options.moreAt meta.options.moreText meta.options.chompContent}}
         <div class="c-base__links">
           {{#if meta.options.chompContent}}
               {{{include 'chomp_link' className="c-base__link" sep=meta.options.moreAt}}}
@@ -41,7 +41,7 @@
               <span class="c-base__link--more  sep--before">{{{formatSubtitle meta.options.moreText}}}</span>
           {{/if}}
         </div>
-      {{/if}}
+      {{/or}}
   </div>
 </div>
 

--- a/detail/text_detail.handlebars
+++ b/detail/text_detail.handlebars
@@ -27,17 +27,21 @@
             </div>
           {{/if}}
       {{/if}}
-      <div class="c-base__links">
-        {{#if meta.options.chompContent}}
-            {{{include 'chomp_link' className="c-base__link" sep=meta.options.moreAt}}}
-        {{/if}}
-        {{#if meta.options.moreAt}}
-            {{{moreAt meta 'none' className="c-base__link"}}}
-        {{/if}}
-        {{#if meta.options.moreText}}
-            <span class="c-base__link--more  sep--before">{{{formatSubtitle meta.options.moreText}}}</span>
-        {{/if}}
-      </div>
+
+      <!-- Make sure to check if we have anything to display before adding the element. -->
+      {{#if meta.options.moreText}}
+        <div class="c-base__links">
+          {{#if meta.options.chompContent}}
+              {{{include 'chomp_link' className="c-base__link" sep=meta.options.moreAt}}}
+          {{/if}}
+          {{#if meta.options.moreAt}}
+              {{{moreAt meta 'none' className="c-base__link"}}}
+          {{/if}}
+          {{#if meta.options.moreText}}
+              <span class="c-base__link--more  sep--before">{{{formatSubtitle meta.options.moreText}}}</span>
+          {{/if}}
+        </div>
+      {{/if}}
   </div>
 </div>
 

--- a/detail/text_detail.handlebars
+++ b/detail/text_detail.handlebars
@@ -28,7 +28,7 @@
           {{/if}}
       {{/if}}
 
-      <!-- Make sure to check if we have anything to display before adding the element. -->
+      {{!-- Make sure to check if we have anything to display before adding the element. --}}
       {{#or meta.options.moreAt meta.options.moreText meta.options.chompContent}}
         <div class="c-base__links">
           {{#if meta.options.chompContent}}


### PR DESCRIPTION
Adding a check ensures that there are no extra margins added to the bottom of the `text` templates:

<img width="1564" alt="screen shot 2016-08-08 at 2 42 53 pm" src="https://cloud.githubusercontent.com/assets/81969/17491634/6fa28e8a-5d76-11e6-8f74-4e4d85e92932.png">

<img width="1564" alt="screen shot 2016-08-08 at 2 50 23 pm" src="https://cloud.githubusercontent.com/assets/81969/17491885/7f09af4c-5d77-11e6-8e5d-94021b06e755.png">

<img width="1564" alt="screen shot 2016-08-08 at 2 51 23 pm" src="https://cloud.githubusercontent.com/assets/81969/17491917/99d3e0f4-5d77-11e6-94b3-03f8e893593b.png">

There is one IA that is negatively affected by this change and it's the Conversions IA:

<img width="1564" alt="screen shot 2016-08-08 at 2 44 24 pm" src="https://cloud.githubusercontent.com/assets/81969/17491691/a6c4cc70-5d76-11e6-9d83-a474cc030a36.png">

That is not a problem with this PR though. It's solved in a different one: https://github.com/duckduckgo/zeroclickinfo-goodies/pull/3511