### PR TITLE
Dynamically choose source name from the API response

### DIFF
--- a/core/metabar.handlebars
+++ b/core/metabar.handlebars
@@ -14,7 +14,11 @@
             {{#if primaryText}}
                 {{{primaryText}}}
             {{else}}
-                <span class="metabar__item-type">{{l itemType}}</span> DDG.Text.FOR <span class="metabar__term">{{searchTerm}}</span>
+                {{#if sourceNoTransform}}
+                    <span class="metabar__item-type--no-transform">{{l itemType}}</span> DDG.Text.FOR <span class="metabar__term">{{searchTerm}}</span>
+                {{else}}
+                    <span class="metabar__item-type">{{l itemType}}</span> DDG.Text.FOR <span class="metabar__term">{{searchTerm}}</span>
+                {{/if}}
             {{/if}}
         </div>
         {{#if showDropdowns}}

--- a/shared/products_amazon_buy.handlebars
+++ b/shared/products_amazon_buy.handlebars
@@ -1,1 +1,1 @@
-    <span class="detail__callout--pr"><a href="{{url}}" class="btn btn--primary">DDG.Text.MORE_AT Amazon</a></span>
+    <span class="detail__callout--pr"><a href="{{url}}" class="btn btn--primary">DDG.Text.MORE_AT {{meta.sourceName}}</a></span>


### PR DESCRIPTION
@moollaza 
cc: @b2ddg 

This updates the single-item details template to display the source name passed in by the API response. This works with https://github.com/duckduckgo/zeroclickinfo-spice/pull/3472.