### PR TITLE
Added role to image template 

### DIFF
--- a/item/images_item.handlebars
+++ b/item/images_item.handlebars
@@ -1,5 +1,5 @@
 {{~#unless this.n~}}
-<div class="tile  tile--img  has-detail" style="width:{{tileWidth}}px;">
+<div class="tile  tile--img  has-detail" style="width:{{tileWidth}}px;" role="button">
     <div class="tile--img__media">
         <span class="tile--img__media__i"><img class="tile--img__img  js-lazyload" src="" data-src="{{imageProxy thumbnail}}" alt="{{title}}" /></span>
     </div>


### PR DESCRIPTION
I found that I was unable to expand the image search results when using [Vimium](https://vimium.github.io/), added a role to the div with attached events so Vimium can gather hints correctly.

This should improve accessibility aswell, as it adds semantic meaning to the div with eventhandlers.