### PR TITLE
Request smaller image thumbnail using new imageProxyThumbnail

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "duckduckgo-answerbar-templates",
-  "version": "1.6.2",
+  "version": "1.7.2",
   "description": "Templates used in DuckDuckGo's Instant Answers",
   "license": "Apache2",
   "ignore": [

--- a/item/images_item.handlebars
+++ b/item/images_item.handlebars
@@ -1,7 +1,7 @@
 {{~#unless this.n~}}
 <div class="tile  tile--img  has-detail" style="width:{{tileWidth}}px;">
     <div class="tile--img__media">
-        <span class="tile--img__media__i"><img class="tile--img__img  js-lazyload" src="" data-src="{{imageProxy thumbnail}}" alt="{{title}}" /></span>
+        <span class="tile--img__media__i"><img class="tile--img__img  js-lazyload" src="" data-src="{{imageProxyThumbnail thumbnail}}" alt="{{title}}" /></span>
     </div>
     <div class="tile--img__details">
         <div class="tile--img__dimensions">

--- a/item/images_item.handlebars
+++ b/item/images_item.handlebars
@@ -1,7 +1,7 @@
 {{~#unless this.n~}}
 <div class="tile  tile--img  has-detail" style="width:{{tileWidth}}px;">
     <div class="tile--img__media">
-        <span class="tile--img__media__i"><img class="tile--img__img  js-lazyload" src="" data-src="{{imageProxyThumbnail thumbnail}}" alt="{{title}}" /></span>
+        <span class="tile--img__media__i"><img class="tile--img__img  js-lazyload" src="" data-src="{{#if requestThumbnail}}{{imageProxyThumbnail thumbnail}}{{else}}{{imageProxy thumbnail}}{{/if}}" alt="{{title}}" /></span>
     </div>
     <div class="tile--img__details">
         <div class="tile--img__dimensions">

--- a/item/images_item.handlebars
+++ b/item/images_item.handlebars
@@ -1,7 +1,7 @@
 {{~#unless this.n~}}
 <div class="tile  tile--img  has-detail" style="width:{{tileWidth}}px;">
     <div class="tile--img__media">
-        <span class="tile--img__media__i"><img class="tile--img__img  js-lazyload" src="" data-src="{{#if requestThumbnail}}{{imageProxyThumbnail thumbnail}}{{else}}{{imageProxy thumbnail}}{{/if}}" alt="{{title}}" /></span>
+        <span class="tile--img__media__i"><img class="tile--img__img  js-lazyload" src="" data-src="{{#if requestResizedThumbnail}}{{imageProxyThumbnail thumbnail}}{{else}}{{imageProxy thumbnail}}{{/if}}" alt="{{title}}" /></span>
     </div>
     <div class="tile--img__details">
         <div class="tile--img__dimensions">


### PR DESCRIPTION
Request smaller image thumbnails, by using a new helper added to `duckduckgo-template-helpers`