### PR TITLE
Move products_branded_item template over from spice

### DIFF
--- a/item/products_branded_item.handlebars
+++ b/item/products_branded_item.handlebars
@@ -1,0 +1,27 @@
+<div class="tile  tile--pr tile--c has-detail  tile--{{parentId}} {{#if showBrand}}tile--has-brand{{/if}}" data-link="{{url}}">
+    <div class="tile__media  tile__media--pr">
+        <img src="" data-src="{{{imageProxy img}}}" alt="{{title}}" class="tile__media__img  js-lazyload" />
+        {{#and showBadge meta.options.badge}}{{{include meta.options.badge}}}{{/and}}
+    </div>
+    <div class="tile__body  tile__body--pr">
+        {{#if showBrand}}
+            {{{formatTitle brand el="h5" className="tile__title tile__title--brand" classNameSec="tile__title--pr" href="brand_query" optSub=true ellipsis=100}}}
+        {{/if}}
+        {{#if url}}
+            {{{formatTitle heading el="h6" className="tile__title" classNameSec="tile__title--pr" href="url" optSub=true ellipsis=100}}}
+        {{else}}
+            {{{formatTitle heading el="h6" className="tile__title" classNameSec="tile__title--pr" optSub=true   ellipsis=100}}}
+        {{/if}}
+    <div class="tile--pr__sub  one-line">
+        {{#and meta.options.price price}}
+            <span class="tile--pr__price  price  pull-left">{{price}}</span>
+        {{/and}}
+        {{#if meta.options.rating}}
+            <span class="tile--pr__rating  tile__rating  pull-right">
+                {{{starsAndReviews rating reviewCount url_review true}}}
+            </span>
+        {{/if}}
+    </div>
+    </div>
+</div>
+


### PR DESCRIPTION
If we want a static shopping tab, all the templates need to exist in the core template library. This one was missing because we forked it in the last round of experimentation and left it sitting in the spice repo, so it's only injected when there's a trigger.

/cc @aaronharsh @bbraithwaite @tommytommytommy 